### PR TITLE
Minimum Go version needs to be 1.22.0 and not just 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/checkpoint-restore/checkpoint-restore-operator
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/checkpoint-restore/checkpointctl v1.2.1


### PR DESCRIPTION
@rst0git @snprajwal  Unfortunately the dependabot PRs are still failing because the version in `go.mod` needs to be `1.22.0` and not just `1.22`. :shrug: 