### PR TITLE
Replace 1.21 with 1.22 in more locations

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version-file: 'go.mod'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: codespell-project/actions-codespell@v2
         with:
           skip: vendor,*.svg
-      
+
       - name: ShellCheck and shfmt
         run: |
           shellcheck ./test/*.sh
@@ -60,7 +60,7 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: changes
         with:
-          base: 'main'  
+          base: 'main'
           filters: |
             md:
               - 'README.md'

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: 'go.mod'
 
       - name: Install ShellCheck and shfmt
         run: |
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: 'go.mod'
 
       - name: verify go.mod/go.sum
         run: |


### PR DESCRIPTION
Other CI jobs were also hardcoding the version to 1.21. This updates those locations as well.

As suggested by @rst0git this PR now does:
```diff
-         go-version: 1.21
+         go-version-file: 'go.mod'
```