### PR TITLE
ci: add workflow to build and push container image

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,55 @@
+name: container-image
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+  schedule:
+    # Ideally, we would update the image every time the base image
+    # is updated, but this is good enough.
+    # "At minute 15 past every 4th hour from midnight through 23."
+    - cron: "15 0-23/4 * * *"
+
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: container-image-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build:
+    if: ${{ github.repository == 'checkpoint-restore/checkpoint-restore-operator' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to Quay.io
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Build and push image to Docker registry
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            criu/checkpoint-restore-operator:latest
+            quay.io/criu/checkpoint-restore-operator:latest


### PR DESCRIPTION
This pull request adds a GitHub CI workflow to automatically build and push a container image to the following registries:

- https://quay.io/repository/criu/checkpoint-restore-operator
- https://hub.docker.com/r/criu/checkpoint-restore-operator