### PR TITLE
config/manager: update default image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# criu.org/checkpoint-restore-operator-bundle:$VERSION and criu.org/checkpoint-restore-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= criu.org/checkpoint-restore-operator
+# criu/checkpoint-restore-operator-bundle:$VERSION and criu/checkpoint-restore-operator-catalog:$VERSION.
+IMAGE_TAG_BASE ?= criu/checkpoint-restore-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
+  newName: criu/checkpoint-restore-operator
   newTag: latest


### PR DESCRIPTION
This pull request follows up on the discussion in https://github.com/checkpoint-restore/checkpoint-restore-operator/pull/5#discussion_r1672228167 and sets the default container image to [Docker Hub](https://hub.docker.com/r/criu/checkpoint-restore-operator).