### PR TITLE
chore: use uppercase in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
The `AS` instruction is used to assign a stage name in a [multi-stage](https://docs.docker.com/build/building/multi-stage/#use-a-previous-stage-as-a-new-stage) build. While using uppercase for `AS` is not strictly enforced, it is a common convention that makes it consistent with other instructions and improves readability.