### PR TITLE
ci: reduce dependabot frequency

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       all:
         patterns:


### PR DESCRIPTION
Dependabot is too noisy for this repository due to the high frequency of updates for the k8s deps. Reducing the frequency to monthly bumps should help with this.