### PR TITLE
fix: update controller-tools to prevent invalid array in golang.org/x/tools/internal/tokeninternal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.3
-CONTROLLER_TOOLS_VERSION ?= v0.15.0
+CONTROLLER_TOOLS_VERSION ?= v0.17.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.

--- a/config/crd/bases/criu.org_checkpointrestoreoperators.yaml
+++ b/config/crd/bases/criu.org_checkpointrestoreoperators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: checkpointrestoreoperators.criu.org
 spec:
   group: criu.org
@@ -53,11 +53,19 @@ spec:
                     container:
                       type: string
                     maxCheckpointSize:
-                      type: integer
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     maxCheckpoints:
                       type: integer
                     maxTotalSize:
-                      type: integer
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     namespace:
                       type: string
                     pod:
@@ -69,7 +77,11 @@ spec:
               globalPolicy:
                 properties:
                   maxCheckpointSize:
-                    type: integer
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxCheckpointsPerContainer:
                     type: integer
                   maxCheckpointsPerNamespace:
@@ -77,11 +89,23 @@ spec:
                   maxCheckpointsPerPod:
                     type: integer
                   maxTotalSizePerContainer:
-                    type: integer
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxTotalSizePerNamespace:
-                    type: integer
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   maxTotalSizePerPod:
-                    type: integer
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   retainOrphan:
                     type: boolean
                 type: object
@@ -89,11 +113,19 @@ spec:
                 items:
                   properties:
                     maxCheckpointSize:
-                      type: integer
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     maxCheckpoints:
                       type: integer
                     maxTotalSize:
-                      type: integer
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     namespace:
                       type: string
                     retainOrphan:
@@ -104,11 +136,19 @@ spec:
                 items:
                   properties:
                     maxCheckpointSize:
-                      type: integer
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     maxCheckpoints:
                       type: integer
                     maxTotalSize:
-                      type: integer
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     namespace:
                       type: string
                     pod:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,13 +8,6 @@ rules:
   - ""
   resources:
   - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - pods
   verbs:
   - get


### PR DESCRIPTION
This PR updates controller-tools to 0.17 to prevent `invalid array length` error when `go install` golang.org/x/tools/internal/tokeninternal (triggered by `make install`)

Fixes https://github.com/checkpoint-restore/checkpoint-restore-operator/issues/88