### PR TITLE
helm: add Helm chart for checkpoint-restore-operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Dockerfile.cross
 *.swp
 *.swo
 *~
+.DS_Store

--- a/charts/checkpoint-restore-operator/Chart.yaml
+++ b/charts/checkpoint-restore-operator/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: checkpoint-restore-operator
+description: Kubernetes operator for CRIU checkpoint/restore
+type: application
+version: 0.1.0
+appVersion: "0.0.0"
+

--- a/charts/checkpoint-restore-operator/crds/criu.org_checkpointrestoreoperators.yaml
+++ b/charts/checkpoint-restore-operator/crds/criu.org_checkpointrestoreoperators.yaml
@@ -1,0 +1,129 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: checkpointrestoreoperators.criu.org
+spec:
+  group: criu.org
+  names:
+    kind: CheckpointRestoreOperator
+    listKind: CheckpointRestoreOperatorList
+    plural: checkpointrestoreoperators
+    singular: checkpointrestoreoperator
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: CheckpointRestoreOperator is the Schema for the checkpointrestoreoperators
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CheckpointRestoreOperatorSpec defines the desired state of
+              CheckpointRestoreOperator
+            properties:
+              applyPoliciesImmediately:
+                type: boolean
+              checkpointDirectory:
+                description: 'Important: Run "make" to regenerate code after modifying
+                  this file'
+                type: string
+              containerPolicies:
+                items:
+                  properties:
+                    container:
+                      type: string
+                    maxCheckpointSize:
+                      type: integer
+                    maxCheckpoints:
+                      type: integer
+                    maxTotalSize:
+                      type: integer
+                    namespace:
+                      type: string
+                    pod:
+                      type: string
+                    retainOrphan:
+                      type: boolean
+                  type: object
+                type: array
+              globalPolicy:
+                properties:
+                  maxCheckpointSize:
+                    type: integer
+                  maxCheckpointsPerContainer:
+                    type: integer
+                  maxCheckpointsPerNamespace:
+                    type: integer
+                  maxCheckpointsPerPod:
+                    type: integer
+                  maxTotalSizePerContainer:
+                    type: integer
+                  maxTotalSizePerNamespace:
+                    type: integer
+                  maxTotalSizePerPod:
+                    type: integer
+                  retainOrphan:
+                    type: boolean
+                type: object
+              namespacePolicies:
+                items:
+                  properties:
+                    maxCheckpointSize:
+                      type: integer
+                    maxCheckpoints:
+                      type: integer
+                    maxTotalSize:
+                      type: integer
+                    namespace:
+                      type: string
+                    retainOrphan:
+                      type: boolean
+                  type: object
+                type: array
+              podPolicies:
+                items:
+                  properties:
+                    maxCheckpointSize:
+                      type: integer
+                    maxCheckpoints:
+                      type: integer
+                    maxTotalSize:
+                      type: integer
+                    namespace:
+                      type: string
+                    pod:
+                      type: string
+                    retainOrphan:
+                      type: boolean
+                  type: object
+                type: array
+            type: object
+          status:
+            description: CheckpointRestoreOperatorStatus defines the observed state
+              of CheckpointRestoreOperator
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/checkpoint-restore-operator/templates/_helpers.tpl
+++ b/charts/checkpoint-restore-operator/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{- define "cro.name" -}}
+checkpoint-restore-operator
+{{- end -}}
+
+{{- define "cro.fullname" -}}
+{{- if .Release.Name -}}
+{{- printf "%s-%s" .Release.Name (include "cro.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- include "cro.name" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cro.saName" -}}
+{{- if .Values.serviceAccount.name -}}
+{{ .Values.serviceAccount.name }}
+{{- else -}}
+{{ include "cro.fullname" . }}
+{{- end -}}
+{{- end -}}
+

--- a/charts/checkpoint-restore-operator/templates/deployment.yaml
+++ b/charts/checkpoint-restore-operator/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cro.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: checkpoint-restore-operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: {{ include "cro.saName" . }}
+      terminationGracePeriodSeconds: 10
+
+      containers:
+      {{- if .Values.metrics.enabled }}
+      - name: kube-rbac-proxy
+        image: {{ .Values.proxy.image }}
+        args:
+          - --secure-listen-address=0.0.0.0:8443
+          - --upstream=http://127.0.0.1:8080/
+          - --logtostderr=true
+          - --v=0
+        ports:
+          - containerPort: 8443
+            name: https
+            protocol: TCP
+        resources:
+{{ toYaml .Values.proxy.resources | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+      {{- end }}
+
+      - name: manager
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - /manager
+        args:
+          - --health-probe-bind-address={{ (default ":8081" .Values.manager.healthProbeBindAddress) }}
+          - --metrics-bind-address={{ (default "127.0.0.1:8080" .Values.manager.metricsBindAddress) }}
+
+          {{- if .Values.leaderElection.enabled }}
+          - --leader-elect
+          {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+          allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+          capabilities:
+            drop: ["ALL"]
+            add:
+            {{- range .Values.securityContext.addCapabilities }}
+              - {{ . | quote }}
+            {{- end }}
+        volumeMounts:
+          - name: kubelet-checkpoints
+            mountPath: /var/lib/kubelet/checkpoints
+
+      volumes:
+        - name: kubelet-checkpoints
+          hostPath:
+            path: {{ .Values.checkpointDir.hostPath }}
+            type: Directory
+

--- a/charts/checkpoint-restore-operator/templates/rbac.yaml
+++ b/charts/checkpoint-restore-operator/templates/rbac.yaml
@@ -1,0 +1,99 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cro.fullname" . }}-leader-election-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get","list","watch","create","update","patch","delete"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get","list","watch","create","update","patch","delete"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create","patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cro.fullname" . }}-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cro.fullname" . }}-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "cro.saName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cro.fullname" . }}-manager-role
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get","list","watch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get","list","watch"]
+- apiGroups: ["criu.org"]
+  resources: ["checkpointrestoreoperators"]
+  verbs: ["create","delete","get","list","patch","update","watch"]
+- apiGroups: ["criu.org"]
+  resources: ["checkpointrestoreoperators/finalizers"]
+  verbs: ["update"]
+- apiGroups: ["criu.org"]
+  resources: ["checkpointrestoreoperators/status"]
+  verbs: ["get","patch","update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cro.fullname" . }}-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "cro.fullname" . }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "cro.saName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.metrics.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cro.fullname" . }}-metrics-reader
+rules:
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cro.fullname" . }}-proxy-role
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cro.fullname" . }}-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "cro.fullname" . }}-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "cro.saName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+

--- a/charts/checkpoint-restore-operator/templates/service-metrics.yaml
+++ b/charts/checkpoint-restore-operator/templates/service-metrics.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cro.fullname" . }}-controller-manager-metrics-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: checkpoint-restore-operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+{{- end }}
+

--- a/charts/checkpoint-restore-operator/templates/serviceaccount.yaml
+++ b/charts/checkpoint-restore-operator/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cro.saName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: checkpoint-restore-operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/checkpoint-restore-operator/values.yaml
+++ b/charts/checkpoint-restore-operator/values.yaml
@@ -1,0 +1,54 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/checkpoint-restore/checkpoint-restore-operator
+  tag: latest
+  pullPolicy: IfNotPresent
+
+leaderElection:
+  enabled: true
+
+checkpointDir:
+  hostPath: /var/lib/kubelet/checkpoints
+
+serviceAccount:
+  create: true
+  name: ""
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 64Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+securityContext:
+  runAsUser: 0
+  allowPrivilegeEscalation: true
+  dropAllCapabilities: true
+  addCapabilities:
+    - DAC_OVERRIDE
+    - FOWNER
+
+metrics:
+  enabled: true
+
+proxy:
+  image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 5m
+      memory: 64Mi
+
+manager:
+  healthProbeBindAddress: ":8081"
+  metricsBindAddress: "127.0.0.1:8080"
+


### PR DESCRIPTION
Adds a Helm chart for deploying checkpoint-restore-operator.

The chart includes:

- CRD installation
- ServiceAccount
- Leader election RBAC
- Manager ClusterRole + ClusterRoleBinding
- Optional metrics proxy (kube-rbac-proxy)
- Metrics Service
- Configurable image, resources, leader election, and checkpoint directory

The chart mirrors the current kustomize deployment layout.

Closes #90
