### PR TITLE
add containerd annotation support for checkpoint metadata parsing

### DIFF
--- a/internal/controller/checkpointrestoreoperator_controller.go
+++ b/internal/controller/checkpointrestoreoperator_controller.go
@@ -331,6 +331,15 @@ func getCheckpointArchiveInformation(log logr.Logger, checkpointPath string) (*c
 	if err != nil {
 		return nil, err
 	}
+
+	if dumpSpec.Annotations["io.kubernetes.cri.sandbox-namespace"] != "" {
+		return &checkpointDetails{
+			namespace: dumpSpec.Annotations["io.kubernetes.cri.sandbox-namespace"],
+			pod:       dumpSpec.Annotations["io.kubernetes.cri.sandbox-name"],
+			container: dumpSpec.Annotations["io.kubernetes.cri.container-name"],
+		}, nil
+	}
+
 	labels := make(map[string]string)
 
 	if err := json.Unmarshal([]byte(dumpSpec.Annotations["io.kubernetes.cri-o.Labels"]), &labels); err != nil {


### PR DESCRIPTION
Fixes #95 

This PR adds a conditional check to check for containerd annotations and properly parse containerd annotations.

Previously, the operator used to silently skip containerd checkpointing by hitting a JSON unmarshal error on the empty io.kubernetes.cri-o.Labels annotations.

**Annotation difference :**

CRI-O stores metadata as a JSON blob inside a single annotation, which must be unmarshalled: so `io.kubernetes.cri-o.Labels` has JSON containing `io.kubernetes.pod.namespace, io.kubernetes.pod.name, io.kubernetes.container.name` etc.

On the other hand, containerd stores metadata as flat, individual annotations, in contrast to the single one. (`io.kubernetes.cri.sandbox-namespace, io.kubernetes.cri.sandbox-name, io.kubernetes.cri.container-name`)

For reference, I took a look at the source code https://github.com/cri-o/cri-o/blob/main/internal/annotations/annotations.go and here : https://github.com/containerd/containerd/blob/main/internal/cri/annotations/annotations.go

Before the fix
<img width="1271" height="200" alt="image" src="https://github.com/user-attachments/assets/fd25cc56-479c-4c68-8280-54695414e1d2" />

After fix
<img width="1512" height="141" alt="Screenshot 2026-04-15 at 11 23 45 PM" src="https://github.com/user-attachments/assets/a81aaeee-c873-4f76-a7c0-dfa17b4f56b1" />
