### PR TITLE
Bug Fix: Replacing depricated kubebuilder image

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.1 
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
Offical image of kubebuilder is depericated according to this ->
https://github.com/kubernetes-sigs/kubebuilder/discussions/3907 
and is recommended to use image from location quay.io/brancz/kube-rbac-proxy