### PR TITLE
controller: fix nil pointer panic in applyPolicies when no CheckpointRestoreOperator exists 

### DIFF
--- a/internal/controller/checkpointrestoreoperator_controller.go
+++ b/internal/controller/checkpointrestoreoperator_controller.go
@@ -408,19 +408,19 @@ func applyPolicies(log logr.Logger, details *checkpointDetails) {
 	} else {
 		// Apply global policies if no specific policy found
 		handleCheckpointsForLevel(log, details, "container", Policy{
-			RetainOrphan:      *retainOrphan,
+			RetainOrphan:      ifNil(retainOrphan),
 			MaxCheckpoints:    maxCheckpointsPerContainer,
 			MaxCheckpointSize: maxCheckpointSize,
 			MaxTotalSize:      maxTotalSizePerContainer,
 		})
 		handleCheckpointsForLevel(log, details, "pod", Policy{
-			RetainOrphan:      *retainOrphan,
+			RetainOrphan:      ifNil(retainOrphan),
 			MaxCheckpoints:    maxCheckpointsPerPod,
 			MaxCheckpointSize: maxCheckpointSize,
 			MaxTotalSize:      maxTotalSizePerPod,
 		})
 		handleCheckpointsForLevel(log, details, "namespace", Policy{
-			RetainOrphan:      *retainOrphan,
+			RetainOrphan:      ifNil(retainOrphan),
 			MaxCheckpoints:    maxCheckpointsPerNamespace,
 			MaxCheckpointSize: maxCheckpointSize,
 			MaxTotalSize:      maxTotalSizePerNamespace,

--- a/internal/controller/gc_policy_test.go
+++ b/internal/controller/gc_policy_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controller
+
+import (
+	"os"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("applyPolicies", func() {
+	var tmpDir string
+	var savedDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "gc-policy-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		savedDir = checkpointDirectory
+		checkpointDirectory = tmpDir
+
+		resetAllPoliciesToDefault(logr.Discard())
+	})
+
+	AfterEach(func() {
+		checkpointDirectory = savedDir
+		os.RemoveAll(tmpDir)
+	})
+
+	It("does not panic when retainOrphan is nil", func() {
+		// retainOrphan is nil after resetAllPoliciesToDefault.
+		// Before the fix (*retainOrphan was used directly) this panicked.
+		// After the fix (ifNil(retainOrphan)) this must return cleanly.
+		Expect(retainOrphan).To(BeNil())
+
+		details := &checkpointDetails{
+			namespace: "default",
+			pod:       "test-pod",
+			container: "test-container",
+		}
+
+		Expect(func() {
+			applyPolicies(logr.Discard(), details)
+		}).NotTo(Panic())
+	})
+})

--- a/internal/controller/gc_policy_test.go
+++ b/internal/controller/gc_policy_test.go
@@ -40,7 +40,7 @@ var _ = Describe("applyPolicies", func() {
 
 	AfterEach(func() {
 		checkpointDirectory = savedDir
-		os.RemoveAll(tmpDir)
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
 	})
 
 	It("does not panic when retainOrphan is nil", func() {


### PR DESCRIPTION
retainOrphan is a *bool that is only set when a CheckpointRestoreOperator
resource is reconciled. When only a CheckpointSchedule is used, it stays
nil. The global policy fallback in applyPolicies dereferenced it directly
(*retainOrphan) instead of using the ifNil helper that every other branch
already uses, causing a nil pointer panic whenever a checkpoint was created
or a pod was deleted.

Replace all three bare *retainOrphan dereferences in the else branch with
ifNil(retainOrphan).

fix #104 